### PR TITLE
Temporary Certificate Validation Changes to retrieve-current-flag-sta…

### DIFF
--- a/current-flag-status/retrieve-current-flag-status.js
+++ b/current-flag-status/retrieve-current-flag-status.js
@@ -3,11 +3,21 @@ const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
 const fs = require('fs');
 
-
-// Define an async function that takes a URL as an argument and returns a promise
 async function getFlagDescription(url) {
+  const currentDate = new Date();
+
+  // Define the cutoff date
+  const cutoffDate = new Date('2025-08-15');
+
+  // Configure axios to ignore SSL issues if before cutoff date
+  const axiosConfig = {
+    httpsAgent: new (require('https').Agent)({
+      rejectUnauthorized: currentDate > cutoffDate // Only validate certificates after cutoff date
+    })
+  };
+
   // Use axios to send a GET request to the URL
-  return axios.get(url)
+  return axios.get(url, axiosConfig)
     .then(function(response) {
       // Get the data from the response
       var data = response.data;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request implements changes that allow the flag status retrieval script to run even if the host website (swfd.org) uses an expired certificate. It is only temporary and requires validation starting August 15, 2025.

## Summary by CodeRabbit

- **New Features**
  - Improved HTTPS request handling by conditionally disabling SSL certificate validation until August 15, 2025. After this date, SSL certificates will be validated as usual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->